### PR TITLE
This project repo uses Grunt instead of Gulp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Furthermore, there are two ways to access the application:
 ## Getting Started
 To get the application running, perform the following steps:
 
-Install **node.js**. Then **gulp** and **bower** if you haven't yet.
+Install **node.js**. Then **grunt** and **bower** if you haven't yet.
 
 ```bash
-    $ npm -g install gulp bower
+    $ npm -g install grunt bower
 ```    
 
 After that, let's clone the repository project:


### PR DESCRIPTION
I guess the install syntax is the same. people tend to copy these commands into their terminal. Not a big issue, just wanted to let you know.
